### PR TITLE
Save published data in file metadata

### DIFF
--- a/plugins/File Metadata/extractors/eze.py
+++ b/plugins/File Metadata/extractors/eze.py
@@ -1,3 +1,4 @@
+import arrow
 import __hpx__ as hpx
 from . import common
 
@@ -47,6 +48,10 @@ class Eze(common.Extractor):
             msource = filedata.get('source')
             if msource:
                 d.setdefault('urls', []).append(f"https://{msource['site']}.org/g/{msource['gid']}/{msource['token']}")
+
+            mupdate = filedata.get("upload_date")
+            if mupdate:
+                d['pub_date'] = arrow.get(*mupdate)
 
         return d
 

--- a/plugins/File Metadata/hplugin.json
+++ b/plugins/File Metadata/hplugin.json
@@ -2,7 +2,7 @@
     "id": "e38e24e4-8ca8-420e-b52b-c75510097653",
     "shortname": "file-metadata",
     "name": "File Metadata",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Extracts and applies metadata from a file accompanying a gallery. Supports files produced from eze, e-hentai-downloader and hdoujin",
     "author": "Twiddly",
     "update_url": "https://github.com/happypandax/plugins/tree/master/plugins/File%20Metadata",

--- a/plugins/File Metadata/readme.md
+++ b/plugins/File Metadata/readme.md
@@ -47,6 +47,9 @@ Follow these steps to add support for more kind of files:
 
 # Changelog
 
+- `1.0.3`
+    - Updated the eze handler to save uploaded date as published date
+
 - `1.0.2`
     - Fixed a bug where not all metadata would be applied
 


### PR DESCRIPTION
This fix adds published date to be saved from the file metadata. Published date uses eze's format, and thus is saved as `upload_date` in file.